### PR TITLE
Update to futures 0.3

### DIFF
--- a/argonautica-c/src/hash.rs
+++ b/argonautica-c/src/hash.rs
@@ -98,12 +98,8 @@ pub extern "C" fn argonautica_hash(
     }
 
     let backend: Backend = backend.into();
-    let password_clearing = if password_clearing == 0 { false } else { true };
-    let secret_key_clearing = if secret_key_clearing == 0 {
-        false
-    } else {
-        true
-    };
+    let password_clearing = password_clearing != 0;
+    let secret_key_clearing = secret_key_clearing != 0;
     let variant: Variant = variant.into();
     let version: Version = version.into();
 

--- a/argonautica-c/src/utils.rs
+++ b/argonautica-c/src/utils.rs
@@ -7,8 +7,8 @@ use argonautica_variant_t;
 
 fn base64_len(len: u32) -> usize {
     let bits = 8 * len as usize;
-    let chars = bits / 6 + if bits % 6 != 0 { 1 } else { 0 };
-    chars
+
+    bits / 6 + if bits % 6 != 0 { 1 } else { 0 }
 }
 
 /// Function that returns the length of a string-encoded hash (in bytes and including the NULL byte).

--- a/argonautica-c/src/verify.rs
+++ b/argonautica-c/src/verify.rs
@@ -38,12 +38,8 @@ pub extern "C" fn argonautica_verify(
     }
 
     let backend: Backend = backend.into();
-    let password_clearing = if password_clearing == 0 { false } else { true };
-    let secret_key_clearing = if secret_key_clearing == 0 {
-        false
-    } else {
-        true
-    };
+    let password_clearing = password_clearing != 0;
+    let secret_key_clearing = secret_key_clearing != 0;
 
     let mut verifier = Verifier::default();
     verifier

--- a/argonautica-rs/Cargo.toml
+++ b/argonautica-rs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "argonautica"
 version = "0.2.1" # remember to update html_root_url
+edition = "2018"
 
 authors = ["Brian Myers <brian.carl.myers@gmail.com>"]
 categories = ["algorithms", "api-bindings", "authentication", "cryptography"]
@@ -29,8 +30,7 @@ simd = []
 base64 = "0.10"
 bitflags = "1.1"
 failure = "0.1"
-futures = "0.1"
-futures-cpupool = "0.1"
+futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2"
 log = "0.4"
 nom = "5.0"

--- a/argonautica-rs/benches/bench_crates.rs
+++ b/argonautica-rs/benches/bench_crates.rs
@@ -9,8 +9,7 @@ use argonautica::config::{
     default_lanes, DEFAULT_HASH_LEN, DEFAULT_ITERATIONS, DEFAULT_MEMORY_SIZE, DEFAULT_SALT_LEN,
 };
 use criterion::{Criterion, Fun};
-use rand::rngs::OsRng;
-use rand::RngCore;
+use rand::{rngs::OsRng, RngCore};
 
 const PASSWORD: &str = "P@ssw0rd";
 const SAMPLE_SIZE: usize = 10;
@@ -30,9 +29,8 @@ fn bench_crates(c: &mut Criterion) {
 
             let password = PASSWORD.as_bytes();
 
-            let mut rng = OsRng::new().unwrap();
             let mut salt = [0u8; DEFAULT_SALT_LEN as usize];
-            rng.fill_bytes(&mut salt);
+            OsRng.fill_bytes(&mut salt);
 
             hasher.hash(
                 /* out */ &mut out,
@@ -72,9 +70,8 @@ fn bench_crates(c: &mut Criterion) {
         b.iter(|| {
             let password = PASSWORD.as_bytes();
 
-            let mut rng = OsRng::new().unwrap();
             let mut salt = [0u8; DEFAULT_SALT_LEN as usize];
-            rng.fill_bytes(&mut salt);
+            OsRng.fill_bytes(&mut salt);
 
             let _ = argon2::hash_raw(password, &salt[..], &config).unwrap();
         });

--- a/argonautica-rs/src/backend/c/decode.rs
+++ b/argonautica-rs/src/backend/c/decode.rs
@@ -1,8 +1,7 @@
 #![cfg(test)]
 
-use output::HashRaw;
-use Error;
+use crate::{output::HashRaw, Error};
 
-pub(crate) fn decode_c(_hash: &str) -> Result<HashRaw, Error> {
+pub fn decode_c(_hash: &str) -> Result<HashRaw, Error> {
     unimplemented!(); // TODO:
 }

--- a/argonautica-rs/src/backend/c/encode.rs
+++ b/argonautica-rs/src/backend/c/encode.rs
@@ -2,12 +2,10 @@
 
 use std::ffi::CStr;
 
-use libc;
+use crate::output::HashRaw;
+use crate::{ffi, Error, ErrorKind};
 
-use output::HashRaw;
-use {ffi, Error, ErrorKind};
-
-pub(crate) fn encode_c(hash_raw: &HashRaw) -> Result<String, Error> {
+pub fn encode_c(hash_raw: &HashRaw) -> Result<String, Error> {
     let encoded_len = unsafe {
         ffi::argon2_encodedlen(
             hash_raw.iterations(),

--- a/argonautica-rs/src/backend/c/hash_raw.rs
+++ b/argonautica-rs/src/backend/c/hash_raw.rs
@@ -1,7 +1,7 @@
 use std::ffi::CStr;
 
-use output::HashRaw;
-use {ffi, Error, ErrorKind, Hasher};
+use crate::output::HashRaw;
+use crate::{ffi, Error, ErrorKind, Hasher};
 
 impl<'a> Hasher<'a> {
     pub(crate) fn hash_raw_c(&mut self) -> Result<HashRaw, Error> {

--- a/argonautica-rs/src/backend/c/mod.rs
+++ b/argonautica-rs/src/backend/c/mod.rs
@@ -3,6 +3,6 @@ mod encode;
 mod hash_raw;
 
 #[cfg(test)]
-pub(crate) use self::decode::decode_c;
+pub use decode::decode_c;
 #[cfg(test)]
-pub(crate) use self::encode::encode_c;
+pub use encode::encode_c;

--- a/argonautica-rs/src/backend/mod.rs
+++ b/argonautica-rs/src/backend/mod.rs
@@ -1,6 +1,6 @@
-mod c;
-mod rust;
+pub mod c;
+pub mod rust;
 
 #[cfg(test)]
-pub(crate) use self::c::encode_c;
-pub(crate) use self::rust::decode_rust;
+pub use c::encode_c;
+pub use rust::decode_rust;

--- a/argonautica-rs/src/backend/rust/decode.rs
+++ b/argonautica-rs/src/backend/rust/decode.rs
@@ -1,10 +1,8 @@
-use base64;
+use crate::config::{Variant, Version};
+use crate::output::HashRaw;
+use crate::{Error, ErrorKind};
 
-use config::{Variant, Version};
-use output::HashRaw;
-use {Error, ErrorKind};
-
-pub(crate) fn decode_rust(hash: &str) -> Result<HashRaw, Error> {
+pub fn decode_rust(hash: &str) -> Result<HashRaw, Error> {
     let (rest, intermediate) = parse_hash(hash).map_err(|_| {
         Error::new(ErrorKind::HashDecodeError).add_context(format!("Hash: {}", &hash))
     })?;
@@ -15,7 +13,7 @@ pub(crate) fn decode_rust(hash: &str) -> Result<HashRaw, Error> {
         iterations: intermediate.iterations,
         lanes: intermediate.lanes,
         memory_size: intermediate.memory_size,
-        raw_hash_bytes: raw_hash_bytes,
+        raw_hash_bytes,
         raw_salt_bytes: intermediate.raw_salt_bytes,
         variant: intermediate.variant,
         version: intermediate.version,
@@ -32,7 +30,7 @@ struct IntermediateStruct {
     raw_salt_bytes: Vec<u8>,
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 named!(parse_hash<&str, IntermediateStruct>, do_parse!(
     take_until!("$") >>
     take!(1) >>
@@ -72,8 +70,8 @@ mod tests {
     use rand::{RngCore, SeedableRng};
 
     use super::*;
-    use backend::c::decode_c;
-    use hasher::Hasher;
+    use crate::backend::c::decode_c;
+    use crate::hasher::Hasher;
 
     #[test]
     fn test_decode() {

--- a/argonautica-rs/src/backend/rust/encode.rs
+++ b/argonautica-rs/src/backend/rust/encode.rs
@@ -1,6 +1,4 @@
-use base64;
-
-use output::HashRaw;
+use crate::output::HashRaw;
 
 impl HashRaw {
     pub(crate) fn encode_rust(&self) -> String {
@@ -24,8 +22,8 @@ mod tests {
     use rand::rngs::StdRng;
     use rand::{RngCore, SeedableRng};
 
-    use backend::encode_c;
-    use hasher::Hasher;
+    use crate::backend::encode_c;
+    use crate::hasher::Hasher;
 
     #[test]
     fn test_encode_against_c() {

--- a/argonautica-rs/src/backend/rust/mod.rs
+++ b/argonautica-rs/src/backend/rust/mod.rs
@@ -5,4 +5,4 @@ mod encode;
 #[cfg(feature = "development")]
 mod hash_raw;
 
-pub(crate) use self::decode::decode_rust;
+pub use self::decode::decode_rust;

--- a/argonautica-rs/src/config/backend.rs
+++ b/argonautica-rs/src/config/backend.rs
@@ -1,5 +1,5 @@
-use config::defaults::DEFAULT_BACKEND;
-use {Error, ErrorKind};
+use crate::config::defaults::DEFAULT_BACKEND;
+use crate::{Error, ErrorKind};
 
 impl Default for Backend {
     /// Returns [`Backend::C`](enum.Backend.html#variant.C)
@@ -59,7 +59,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<Backend>();
     }
@@ -67,7 +66,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<Backend>();
     }

--- a/argonautica-rs/src/config/defaults.rs
+++ b/argonautica-rs/src/config/defaults.rs
@@ -1,17 +1,16 @@
-use futures_cpupool::CpuPool;
-use num_cpus;
+use futures::executor::ThreadPool;
 
-use config::{Backend, Variant, Version};
+use crate::config::{Backend, Variant, Version};
 
 /// Returns a [`CpuPool`](https://docs.rs/futures-cpupool/0.1.8/futures_cpupool/struct.CpuPool.html)
 /// with threads equal to the number of logical cores on your machine
 #[inline(always)]
-pub fn default_cpu_pool() -> CpuPool {
-    CpuPool::new(num_cpus::get())
+pub fn default_thread_pool() -> ThreadPool {
+    ThreadPool::new().expect("thread pool creation")
 }
 
 #[cfg(feature = "serde")]
-pub(crate) fn default_cpu_pool_serde() -> Option<CpuPool> {
+pub(crate) fn default_thread_pool_serde() -> Option<ThreadPool> {
     None
 }
 

--- a/argonautica-rs/src/config/flags.rs
+++ b/argonautica-rs/src/config/flags.rs
@@ -26,7 +26,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<Flags>();
     }
@@ -34,7 +33,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<Flags>();
     }

--- a/argonautica-rs/src/config/hasher_config.rs
+++ b/argonautica-rs/src/config/hasher_config.rs
@@ -1,8 +1,7 @@
-use futures_cpupool::CpuPool;
-
-use config::defaults::*;
-use config::{Backend, Flags, Variant, Version};
-use {Error, ErrorKind};
+use crate::config::defaults::*;
+use crate::config::{Backend, Flags, Variant, Version};
+use crate::{Error, ErrorKind};
+use futures::executor::ThreadPool;
 
 const PANIC_WARNING: &str = "Your program will error if you use this configuration";
 
@@ -19,10 +18,10 @@ pub struct HasherConfig {
         serde(
             skip_serializing,
             skip_deserializing,
-            default = "default_cpu_pool_serde"
+            default = "default_thread_pool_serde"
         )
     )]
-    cpu_pool: Option<CpuPool>,
+    cpu_pool: Option<ThreadPool>,
     hash_len: u32,
     iterations: u32,
     lanes: u32,
@@ -41,7 +40,7 @@ impl HasherConfig {
         self.backend
     }
     #[allow(missing_docs)]
-    pub fn cpu_pool(&self) -> Option<CpuPool> {
+    pub fn cpu_pool(&self) -> Option<ThreadPool> {
         match self.cpu_pool {
             Some(ref cpu_pool) => Some(cpu_pool.clone()),
             None => None,
@@ -123,7 +122,7 @@ impl HasherConfig {
         });
         self.backend = backend;
     }
-    pub(crate) fn set_cpu_pool(&mut self, cpu_pool: CpuPool) {
+    pub(crate) fn set_cpu_pool(&mut self, cpu_pool: ThreadPool) {
         self.cpu_pool = Some(cpu_pool);
     }
     pub(crate) fn set_hash_len(&mut self, hash_len: u32) {
@@ -272,7 +271,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<HasherConfig>();
     }
@@ -280,7 +278,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<HasherConfig>();
     }

--- a/argonautica-rs/src/config/variant.rs
+++ b/argonautica-rs/src/config/variant.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use config::defaults::DEFAULT_VARIANT;
-use {Error, ErrorKind};
+use crate::config::defaults::DEFAULT_VARIANT;
+use crate::{Error, ErrorKind};
 
 impl Default for Variant {
     /// Returns [`Variant::Argon2id`](enum.Variant.html#variant.Argon2id)
@@ -100,7 +100,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<Variant>();
     }
@@ -108,7 +107,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<Variant>();
     }

--- a/argonautica-rs/src/config/verifier_config.rs
+++ b/argonautica-rs/src/config/verifier_config.rs
@@ -1,8 +1,8 @@
-use futures_cpupool::CpuPool;
+use futures::executor::ThreadPool;
 
 #[cfg(feature = "serde")]
-use config::defaults::default_cpu_pool_serde;
-use config::Backend;
+use crate::config::defaults::default_thread_pool_serde;
+use crate::config::Backend;
 
 /// Read-only configuration for [`Verifier`](../struct.Verifier.html). Can be obtained by calling
 /// the [`config`](../struct.Verifier.html#method.config) method on an instance of
@@ -17,10 +17,10 @@ pub struct VerifierConfig {
         serde(
             skip_serializing,
             skip_deserializing,
-            default = "default_cpu_pool_serde"
+            default = "default_thread_pool_serde"
         )
     )]
-    pub(crate) cpu_pool: Option<CpuPool>,
+    pub(crate) cpu_pool: Option<ThreadPool>,
     pub(crate) password_clearing: bool,
     pub(crate) secret_key_clearing: bool,
     pub(crate) threads: u32,
@@ -32,7 +32,7 @@ impl VerifierConfig {
         self.backend
     }
     #[allow(missing_docs)]
-    pub fn cpu_pool(&self) -> Option<CpuPool> {
+    pub fn cpu_pool(&self) -> Option<ThreadPool> {
         match self.cpu_pool {
             Some(ref cpu_pool) => Some(cpu_pool.clone()),
             None => None,
@@ -55,7 +55,7 @@ impl VerifierConfig {
 impl VerifierConfig {
     pub(crate) fn new(
         backend: Backend,
-        cpu_pool: Option<CpuPool>,
+        cpu_pool: Option<ThreadPool>,
         password_clearing: bool,
         secret_key_clearing: bool,
         threads: u32,
@@ -89,7 +89,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<VerifierConfig>();
     }
@@ -97,7 +96,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<VerifierConfig>();
     }

--- a/argonautica-rs/src/config/version.rs
+++ b/argonautica-rs/src/config/version.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use config::defaults::DEFAULT_VERSION;
-use {Error, ErrorKind};
+use crate::config::defaults::DEFAULT_VERSION;
+use crate::{Error, ErrorKind};
 
 impl Default for Version {
     /// Returns [`Version::_0x13`](enum.Version.html#variant._0x13)
@@ -85,7 +85,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<Version>();
     }
@@ -93,7 +92,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<Version>();
     }

--- a/argonautica-rs/src/error.rs
+++ b/argonautica-rs/src/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use ErrorKind;
+use crate::ErrorKind;
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -75,7 +75,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<Error>();
     }
@@ -83,7 +82,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<Error>();
     }

--- a/argonautica-rs/src/input/additional_data.rs
+++ b/argonautica-rs/src/input/additional_data.rs
@@ -1,4 +1,4 @@
-use {Error, ErrorKind};
+use crate::{Error, ErrorKind};
 
 impl From<Vec<u8>> for AdditionalData {
     fn from(bytes: Vec<u8>) -> AdditionalData {
@@ -96,7 +96,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<AdditionalData>();
     }
@@ -104,7 +103,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<AdditionalData>();
     }

--- a/argonautica-rs/src/input/container.rs
+++ b/argonautica-rs/src/input/container.rs
@@ -1,12 +1,14 @@
 #[derive(Debug, Eq, PartialEq, Hash)]
-pub(crate) enum Container<'a> {
+#[allow(missing_docs)]
+pub enum Container<'a> {
     Borrowed(&'a [u8]),
     BorrowedMut(&'a mut [u8]),
     Owned(Vec<u8>),
 }
 
 impl<'a> Container<'a> {
-    pub(crate) fn to_owned(&self) -> Container<'static> {
+    #[allow(missing_docs)]
+    pub fn to_owned(&self) -> Container<'static> {
         match self {
             Container::Borrowed(ref bytes) => Container::Owned(bytes.to_vec()),
             Container::BorrowedMut(ref bytes) => Container::Owned(bytes.to_vec()),

--- a/argonautica-rs/src/input/mod.rs
+++ b/argonautica-rs/src/input/mod.rs
@@ -20,8 +20,8 @@ mod password;
 mod salt;
 mod secret_key;
 
-pub use self::additional_data::AdditionalData;
-pub(crate) use self::container::Container;
-pub use self::password::Password;
-pub use self::salt::Salt;
-pub use self::secret_key::SecretKey;
+pub use additional_data::AdditionalData;
+pub use container::Container;
+pub use password::Password;
+pub use salt::Salt;
+pub use secret_key::SecretKey;

--- a/argonautica-rs/src/input/password.rs
+++ b/argonautica-rs/src/input/password.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use input::Container;
-use {Error, ErrorKind};
+use crate::input::Container;
+use crate::{Error, ErrorKind};
 
 impl<'a> From<&'a str> for Password<'a> {
     fn from(s: &'a str) -> Password<'a> {

--- a/argonautica-rs/src/input/salt.rs
+++ b/argonautica-rs/src/input/salt.rs
@@ -1,7 +1,7 @@
 use rand::rngs::OsRng;
 use rand::RngCore;
 
-use {Error, ErrorKind};
+use crate::{Error, ErrorKind};
 
 impl Default for Salt {
     /// Creates a new <u>random</u> `Salt`.
@@ -168,7 +168,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<Salt>();
     }
@@ -176,7 +175,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<Salt>();
     }

--- a/argonautica-rs/src/input/secret_key.rs
+++ b/argonautica-rs/src/input/secret_key.rs
@@ -1,9 +1,7 @@
 use std::fmt;
 
-use base64;
-
-use input::Container;
-use {Error, ErrorKind};
+use crate::input::Container;
+use crate::{Error, ErrorKind};
 
 impl<'a> From<&'a str> for SecretKey<'a> {
     fn from(s: &'a str) -> SecretKey<'a> {

--- a/argonautica-rs/src/lib.rs
+++ b/argonautica-rs/src/lib.rs
@@ -105,12 +105,10 @@
 //! Here is an example that shows how to use [`Hasher`](struct.Hasher.html)'s custom
 //! configuration options. It provides color on each of the options.
 //! ```
-//! extern crate argonautica;
-//! extern crate futures_cpupool;
 //!
 //! use argonautica::Hasher;
 //! use argonautica::config::{Backend, Variant, Version};
-//! use futures_cpupool::CpuPool;
+//! use futures::executor::ThreadPool;
 //!
 //! fn main() {
 //!     let mut hasher = Hasher::default();
@@ -122,21 +120,21 @@
 //!         // do the work. In the future hopefully a Rust backend will also be supported, but,
 //!         // for the moment, you must use `Backend::C`, which is the default. Using
 //!         // `Backend::Rust` will result in an error (again, for the moment).
-//!         .configure_cpu_pool(CpuPool::new(2))
+//!         .configure_cpu_pool(ThreadPool::new().unwrap())
 //!         // 👆 There are two non-blocking methods on `Hasher` that perform computation on
 //!         // a separate thread and return a `Future` instead of a `Result` (`hash_non_blocking`
 //!         // and `hash_raw_non_blocking`). These methods allow argonautica to play nicely with
-//!         // futures-heavy code, but need a `CpuPool` in order to work. The blocking
-//!         // methods `hash` and `hash_raw` do not use a 'CpuPool'; so if you are using only
+//!         // futures-heavy code, but need a `ThreadPool` in order to work. The blocking
+//!         // methods `hash` and `hash_raw` do not use a 'ThreadPool'; so if you are using only
 //!         // these blocking methods you can ignore this configuration entirely. If, however,
-//!         // you are using the non-blocking methods and would like to provide your own `CpuPool`
-//!         // instead of using the default, which is a lazily created `CpuPool` with the number
+//!         // you are using the non-blocking methods and would like to provide your own `ThreadPool`
+//!         // instead of using the default, which is a lazily created `ThreadPool` with the number
 //!         // of threads equal to the number of logical cores on your machine, you can
-//!         // configure your `Hasher` with a custom `CpuPool` using this method. This
+//!         // configure your `Hasher` with a custom `ThreadPool` using this method. This
 //!         // might be useful if, for example, you are writing code in an environment which
 //!         // makes heavy use of futures, the code you are writing uses both a `Hasher` and
 //!         // a `Verifier`, and you would like both of them to share the same underlying
-//!         // `CpuPool`.
+//!         // `ThreadPool`.
 //!         .configure_hash_len(16) // Default is `32`
 //!         // 👆 The hash length in bytes is configurable. The default is 32. This is probably
 //!         // a good number to use. 16 is also probably fine. You probably shouldn't go below 16
@@ -285,7 +283,6 @@ extern crate blake2_rfc;
 #[macro_use]
 extern crate failure;
 extern crate futures;
-extern crate futures_cpupool;
 extern crate libc;
 #[macro_use]
 extern crate log;

--- a/argonautica-rs/src/output/hash_raw.rs
+++ b/argonautica-rs/src/output/hash_raw.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
-use backend::decode_rust;
-use config::{Variant, Version};
-use Error;
+use crate::backend::decode_rust;
+use crate::config::{Variant, Version};
+use crate::Error;
 
 impl FromStr for HashRaw {
     ///
@@ -95,7 +95,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serialize() {
-        use serde;
         fn assert_serialize<T: serde::Serialize>() {}
         assert_serialize::<HashRaw>();
     }
@@ -103,7 +102,6 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize() {
-        use serde;
         fn assert_deserialize<'de, T: serde::Deserialize<'de>>() {}
         assert_deserialize::<HashRaw>();
     }

--- a/argonautica-rs/src/utils.rs
+++ b/argonautica-rs/src/utils.rs
@@ -1,10 +1,9 @@
 //! Utility functions for generating random bytes, which can be useful for generating
 //! [`SecretKey`](input/struct.SecretKey.html)s, for example.
-use base64;
 use rand::rngs::OsRng;
 use rand::RngCore;
 
-use {Error, ErrorKind};
+use crate::{Error, ErrorKind};
 
 /// A utility function for generating cryptographically-secure random bytes. A quick glance at
 /// this function's source should give you a good idea of what the function is doing.


### PR DESCRIPTION
This raises the futures dependency from the deprecated 0.1 version to 0.3.
This change aims to make the new Rust 2018 keywords "async" and "await" on the returned futures usable.

This also removes the `futures-cpupool` dependency and replaces it with the new `ThreadPool` futures executor.

Additionally, `argonautica-rs` has been switched to the Rust 2018 edition.